### PR TITLE
 Fixes issue with readOnly property

### DIFF
--- a/src/lib/src/shared/json-schema.functions.ts
+++ b/src/lib/src/shared/json-schema.functions.ts
@@ -447,6 +447,12 @@ export function updateInputOptions(layoutNode, schema, jsf) {
     }
   }
 
+  // Map the readOnly property from JsonSchema's camelcased to non-camelcased
+  if (hasOwn(newOptions, 'readOnly')) {
+    newOptions.readonly = newOptions.readOnly;
+    delete newOptions.readOnly;
+  }
+
   // If schema type is integer, enforce by setting multipleOf = 1
   if (schema.type === 'integer' && !hasValue(newOptions.multipleOf)) {
     newOptions.multipleOf = 1;


### PR DESCRIPTION
JsonSchema specifies that the readOnly
property be camel-case, so we need to
map that over to the lower case javascript
property that is used internally.

## PR Type
What changes does this PR include (check all that apply)?
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build process changes
[ ] Documentation changes
[ ] Other... please describe:

## Related issue / current behavior
<!-- Please link to the issue you are resolving, or describe the current behavior that you are modifying. -->


## New behavior
<!-- Describe the new behavior, and how it fixes the original issue. -->


## Does this PR introduce a breaking change?
[ ] Yes
[ ] No

<!-- If this PR contains a breaking change, how will it affect existing applications? What must those applications do to use the updated library after this change is implemented? -->


## Any other relevant information
